### PR TITLE
Refactored public exposure to subclasses. now these are available onl…

### DIFF
--- a/include/bElem.h
+++ b/include/bElem.h
@@ -34,8 +34,7 @@ public:
      */
 
     static videoElement::videoElementDef *vd;
-    std::unique_ptr<bElemStats> status;
-    std::unique_ptr<bElemAttr> attrs;
+
     virtual ALLEGRO_MUTEX *getMyMutex();
     void registerLiveElement(std::shared_ptr<bElem> who);
     void deregisterLiveElement(int instanceId);
@@ -58,6 +57,9 @@ public:
     virtual coords getAbsCoords(direction dir) const;
     virtual  int getType() const;
     virtual int getAnimPh() const;
+    std::shared_ptr<bElemAttr> getAttrs() const;
+    std::shared_ptr<bElemStats> getStats() const;
+
     virtual  float getViewRadius() const;
     virtual bool collect(std::shared_ptr<bElem> collectible);
     virtual bool dropItem(unsigned long int  instanceId);
@@ -98,6 +100,10 @@ public:
 
     void playSound(std::string eventType,std::string event);
 private:
+    std::shared_ptr<bElemStats> status;
+    std::shared_ptr<bElemAttr> attrs;
+
+
     void ps(std::shared_ptr<bElem> who,std::string eventType,std::string event);
     bool provisioned=false;
     bElem(const bElem &) = delete;

--- a/src/bElemAttr.cpp
+++ b/src/bElemAttr.cpp
@@ -116,7 +116,7 @@ bool bElemAttr::isSteppable() const
     std::shared_ptr<bElem> owner=this->owner.lock();
     if(!owner)
         return this->steppable;
-    return this->steppable && !owner->status->isDying() && !owner->status->isDestroying() && !owner->status->isTeleporting();
+    return this->steppable && !owner->getStats()->isDying() && !owner->getStats()->isDestroying() && !owner->getStats()->isTeleporting();
 }
 
 void bElemAttr::setSteppable(bool s)
@@ -127,7 +127,7 @@ void bElemAttr::setSteppable(bool s)
 bool bElemAttr::isMovable() const
 {
     std::shared_ptr<bElem> own=this->owner.lock();
-    return this->movable && !own->status->isDestroying() && !own->status->isDying() && !own->status->isTeleporting();;
+    return this->movable && !own->getStats()->isDestroying() && !own->getStats()->isDying() && !own->getStats()->isTeleporting();;
 }
 
 void bElemAttr::setMovable(bool m)

--- a/src/bunker.cpp
+++ b/src/bunker.cpp
@@ -51,7 +51,7 @@ bunker::~bunker()
 bool bunker::mechanics()
 {
     bool res=bElem::mechanics();
-    if(!res || this->status->isMoving() || this->status->isWaiting() || this->myGun->status->isWaiting())
+    if(!res || this->getStats()->isMoving() || this->getStats()->isWaiting() || this->myGun->getStats()->isWaiting())
         return false;
     int randomTest=bElem::randomNumberGenerator()%1000;
     if(randomTest>965)
@@ -79,7 +79,7 @@ direction bunker::findLongestShot()
     {
         element=this->getElementInDirection((direction)(dir));
         if(element.get()==nullptr) continue;
-        while(element->attrs->isSteppable()==true)
+        while(element->getAttrs()->isSteppable()==true)
         {
             routes[dir]++;
             element=element->getElementInDirection((direction)(dir));
@@ -88,7 +88,7 @@ direction bunker::findLongestShot()
         }
         if (element)
         {
-            if (element->attrs->isKillable()==true)
+            if (element->getAttrs()->isKillable()==true)
             {
                 routes[dir]=655350; // We shoot here, the place, where something to be killed stands at
             }
@@ -106,7 +106,7 @@ direction bunker::findLongestShot()
 bool bunker::selfAlign()
 {
     if(this->getBoard())
-        this->status->setFacing(this->findLongestShot());
+        this->getStats()->setFacing(this->findLongestShot());
     return true;
 }
 

--- a/src/chamber.cpp
+++ b/src/chamber.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<chamber> chamber::makeNewChamber(coords csize)
 void chamber::createFloor()
 {
 #ifdef _VerbousMode_
-    std::cout << "Create floor instance [" << this->status->getInstanceId() << "]\n";
+    std::cout << "Create floor instance [" << this->getStats()->getInstanceId() << "]\n";
     std::cout << " cfsize [";
 #endif
     for (int c = 0; c < this->width; c++)
@@ -42,16 +42,16 @@ void chamber::createFloor()
             std::cout << "Create an object to place\n";
 #endif
             std::shared_ptr<bElem> b = elementFactory::generateAnElement<floorElement>(shared_from_this(),subtype);
-            b->status->setMyPosition((coords)
+            b->getStats()->setMyPosition((coords)
             {
                 c, d
             });
 #ifdef _VerbousMode_
-            std::cout << "created id " << b->status->getInstanceId() << "\n";
+            std::cout << "created id " << b->getStats()->getInstanceId() << "\n";
 #endif
 
 #ifdef _VerbousMode_
-            std::cout << "Push object into column vector id " << b->status->getInstanceId() << "\n";
+            std::cout << "Push object into column vector id " << b->getStats()->getInstanceId() << "\n";
 #endif
             v.push_back(b);
         }
@@ -96,7 +96,7 @@ colour chamber::getChColour()
 
 chamber::~chamber()
 {
-    /*    std::cout<<"Destroy chamber: "<<this->status->getInstanceId()<<"\n";
+    /*    std::cout<<"Destroy chamber: "<<this->getStats()->getInstanceId()<<"\n";
         for (unsigned int cX=0; cX<this->chamberArray.size(); cX++)
         {
            this->chamberArray[cX].clear();

--- a/src/chamberArea.cpp
+++ b/src/chamberArea.cpp
@@ -113,7 +113,7 @@ int chamberArea::calculateSurface(std::shared_ptr<chamber> mychamber)
         {
             for (int y=this->upLeft.y; y<=this->downRight.y; y++)
             {
-                if (mychamber->getElement(x,y)->attrs->isSteppable() && this->checkIfElementIsFree(x,y,mychamber))
+                if (mychamber->getElement(x,y)->getAttrs()->isSteppable() && this->checkIfElementIsFree(x,y,mychamber))
                 {
                     surface_++;
                 }
@@ -140,7 +140,7 @@ void chamberArea::findElementsRec(std::shared_ptr<chamber> mychamber)
         {
             for (int y=this->upLeft.y; y<=this->downRight.y; y++)
             {
-                if (mychamber->getElement(x,y)->attrs->isSteppable() && this->checkIfElementIsFree(x,y,mychamber))
+                if (mychamber->getElement(x,y)->getAttrs()->isSteppable() && this->checkIfElementIsFree(x,y,mychamber))
                 {
                     chamberArea::foundElements.push_back(mychamber->getElement(x,y));
                 }
@@ -195,7 +195,7 @@ void chamberArea::findChambersCloseToSurface(int s,int tolerance)
 
 bool chamberArea::checkIfElementIsFree(int x, int y, std::shared_ptr<chamber> mychamber)
 {
-    if(mychamber->getElement(x,y)->attrs->isSteppable()==false)
+    if(mychamber->getElement(x,y)->getAttrs()->isSteppable()==false)
         return false;
     sNeighboorhood neigh=mychamber->getElement(x,y)->getSteppableNeighboorhood();
     for(int c=0; c<8; c++)

--- a/src/characterStats.cpp
+++ b/src/characterStats.cpp
@@ -35,24 +35,24 @@ void characterStats::countHit(std::shared_ptr<bElem> what)
 {
     if(what==nullptr) return;
 
-    if(what->attrs->isKillable())
+    if(what->getAttrs()->isKillable())
     {
         this->globalPoints++;
-        if(what->attrs->isCollectible())
+        if(what->getAttrs()->isCollectible())
         {
             this->_dPoints++;
             this->updateDexterity();
             return;
         }
-        if(what->attrs->isMovable())
+        if(what->getAttrs()->isMovable())
         {
             this->_dPoints++;
 
-            if(what->status->hasActivatedMechanics())
+            if(what->getStats()->hasActivatedMechanics())
             {
                 this->_dPoints+=3;
             }
-            if(what->status->isDestroying())
+            if(what->getStats()->isDestroying())
             {
                 this->_dPoints+=2;
 

--- a/src/door.cpp
+++ b/src/door.cpp
@@ -35,9 +35,9 @@ bool door::additionalProvisioning()
 bool door::additionalProvisioning(int subtype, int typeId)
 {
     bool res=bElem::additionalProvisioning(subtype,typeId);
-    this->attrs->setSteppable(false);
-    this->attrs->setLocked(true);
-    this->attrs->setOpen(false);
+    this->getAttrs()->setSteppable(false);
+    this->getAttrs()->setLocked(true);
+    this->getAttrs()->setOpen(false);
     return res;
 }
 
@@ -47,12 +47,12 @@ bool door::stepOnAction(bool step, std::shared_ptr<bElem>who)
         return false;
     if(step==true)
     {
-        if(this->attrs->getSubtype()%2==1 )
+        if(this->getAttrs()->getSubtype()%2==1 )
         {
             std::shared_ptr<bElem> k;
-            if( who->attrs->canCollect())
+            if( who->getAttrs()->canCollect())
             {
-                k=who->attrs->getInventory()->getKey(_key,this->attrs->getSubtype(),true);
+                k=who->getAttrs()->getInventory()->getKey(_key,this->getAttrs()->getSubtype(),true);
             }
             if(!k)
             {
@@ -64,13 +64,13 @@ bool door::stepOnAction(bool step, std::shared_ptr<bElem>who)
     }
     else
     {
-        if(this->attrs->getSubtype()%2==1 )
+        if(this->getAttrs()->getSubtype()%2==1 )
         {
-            this->attrs->setOpen(false);
-            this->attrs->setSteppable(this->attrs->isOpen());
-            this->attrs->setLocked(true);
-            this->playSound("Door", (this->attrs->isOpen()) ? "Unlock" : "Lock");
-            this->status->setFacing((!this->attrs->isOpen()) ? UP : LEFT);
+            this->getAttrs()->setOpen(false);
+            this->getAttrs()->setSteppable(this->getAttrs()->isOpen());
+            this->getAttrs()->setLocked(true);
+            this->playSound("Door", (this->getAttrs()->isOpen()) ? "Unlock" : "Lock");
+            this->getStats()->setFacing((!this->getAttrs()->isOpen()) ? UP : LEFT);
         }
     }
     return true;
@@ -79,8 +79,8 @@ bool door::stepOnAction(bool step, std::shared_ptr<bElem>who)
 
 void door::_alignWithOpen()
 {
-        this->status->setFacing((!this->attrs->isOpen()) ? UP : LEFT);
-        this->attrs->setSteppable(this->attrs->isOpen());
+        this->getStats()->setFacing((!this->getAttrs()->isOpen()) ? UP : LEFT);
+        this->getAttrs()->setSteppable(this->getAttrs()->isOpen());
 
 }
 
@@ -92,32 +92,32 @@ bool door::interact(std::shared_ptr<bElem> who)
     std::shared_ptr<bElem> key = nullptr;
     if (!bres)
         return false;
-    if (!this->attrs->isLocked())
+    if (!this->getAttrs()->isLocked())
     {
-        this->status->setInteracted(10);
-        who->status->setWaiting(1);
-        this->attrs->setOpen(!this->attrs->isOpen());
+        this->getStats()->setInteracted(10);
+        who->getStats()->setWaiting(1);
+        this->getAttrs()->setOpen(!this->getAttrs()->isOpen());
         this->_alignWithOpen();
-        this->playSound("Door", (this->attrs->isOpen()) ? "Unlock" : "Lock");
+        this->playSound("Door", (this->getAttrs()->isOpen()) ? "Unlock" : "Lock");
         return true;
     }
-    if (!who->attrs->canCollect())
+    if (!who->getAttrs()->canCollect())
     {
         return false;
     }
-    key = who->attrs->getInventory()->getKey(_key, this->attrs->getSubtype(), this->attrs->getSubtype()%2!=1);
+    key = who->getAttrs()->getInventory()->getKey(_key, this->getAttrs()->getSubtype(), this->getAttrs()->getSubtype()%2!=1);
     if (key != nullptr)
     {
         this->playSound("Door", "Open");
-        this->attrs->setOpen(true);
-        this->attrs->setLocked(false);
+        this->getAttrs()->setOpen(true);
+        this->getAttrs()->setLocked(false);
         this->_alignWithOpen();
     }
     else
     {
         return false;
     }
-    if(key &&  this->attrs->getSubtype()%2!=1)
+    if(key &&  this->getAttrs()->getSubtype()%2!=1)
     {
         this->playSound("Door","CollectKey");
         key->disposeElement();

--- a/src/explosives.cpp
+++ b/src/explosives.cpp
@@ -32,9 +32,9 @@ bool explosives::additionalProvisioning(int subtype, int typeId)
 bool explosives::explode(float radius)
 {
 
-    std::shared_ptr<bElem> step=(this->status->isCollected())?this->status->getCollector().lock()->status->getSteppingOn():this->status->getSteppingOn();
-    coords mc=(this->status->isCollected())?this->status->getCollector().lock()->status->getMyPosition():this->status->getMyPosition();
-    std::shared_ptr<chamber> brd = (this->status->isCollected())?this->status->getCollector().lock()->getBoard():this->getBoard();
+    std::shared_ptr<bElem> step=(this->getStats()->isCollected())?this->getStats()->getCollector().lock()->getStats()->getSteppingOn():this->getStats()->getSteppingOn();
+    coords mc=(this->getStats()->isCollected())?this->getStats()->getCollector().lock()->getStats()->getMyPosition():this->getStats()->getMyPosition();
+    std::shared_ptr<chamber> brd = (this->getStats()->isCollected())?this->getStats()->getCollector().lock()->getBoard():this->getBoard();
     int xs=(mc.x-radius<0)?0:mc.x-radius;
     int xe=(mc.x+radius>=brd->width)?brd->width-1:mc.x+radius;
     int ys=(mc.y-radius<0)?0:mc.y-radius;
@@ -64,8 +64,8 @@ bool explosives::explode(float radius)
 bool explosives::explode()
 {
     std::shared_ptr<bElem> el;
-    coords mc=(!this->status->isCollected())?this->status->getCollector().lock()->status->getMyPosition():this->status->getMyPosition();
-    std::shared_ptr<chamber> brd = (this->status->isCollected())?this->status->getCollector().lock()->getBoard():this->getBoard();
+    coords mc=(!this->getStats()->isCollected())?this->getStats()->getCollector().lock()->getStats()->getMyPosition():this->getStats()->getMyPosition();
+    std::shared_ptr<chamber> brd = (this->getStats()->isCollected())?this->getStats()->getCollector().lock()->getBoard():this->getBoard();
     std::shared_ptr<bElem> step;
     this->playSound("Explosives","Explode"); // This sound must not be looped, otherwise it will be swiped off
     this->removeElement();

--- a/src/goldenApple.cpp
+++ b/src/goldenApple.cpp
@@ -17,12 +17,12 @@ int goldenApple::getType() const
 
 bool goldenApple::hurt(int points)
 {
-    if (this->attrs->getSubtype() != 1)
+    if (this->getAttrs()->getSubtype() != 1)
     {
-        this->attrs->setSubtype(1);
+        this->getAttrs()->setSubtype(1);
         for (unsigned int cnt = 0; cnt < goldenApple::apples.size();)
         {
-            if (goldenApple::apples[cnt]->status->getInstanceId() == this->status->getInstanceId())
+            if (goldenApple::apples[cnt]->getStats()->getInstanceId() == this->getStats()->getInstanceId())
             {
                 goldenApple::apples.erase(goldenApple::apples.begin() + cnt);
                 goldenApple::appleNumber--;
@@ -75,7 +75,7 @@ oState goldenApple::disposeElement()
 {
     for (unsigned int cnt = 0; cnt < goldenApple::apples.size();)
     {
-        if (goldenApple::apples[cnt]->status->getInstanceId() == this->status->getInstanceId())
+        if (goldenApple::apples[cnt]->getStats()->getInstanceId() == this->getStats()->getInstanceId())
         {
             goldenApple::apples.erase(goldenApple::apples.begin() + cnt);
             goldenApple::appleNumber--;
@@ -115,15 +115,15 @@ bool goldenApple::mechanics()
 {
     bool r = explosives::mechanics();
 
-    if (this->attrs->getSubtype() == 0 || this->status->getCollector().expired() || this->status->isWaiting())
+    if (this->getAttrs()->getSubtype() == 0 || this->getStats()->getCollector().expired() || this->getStats()->isWaiting())
     {
         return r;
     }
-    int e = this->status->getCollector().lock()->attrs->getEnergy();
+    int e = this->getStats()->getCollector().lock()->getAttrs()->getEnergy();
     if (e < 100)
     {
-        this->status->setWaiting(25);
-        this->status->getCollector().lock()->attrs->setEnergy(e + 1);
+        this->getStats()->setWaiting(25);
+        this->getStats()->getCollector().lock()->getAttrs()->setEnergy(e + 1);
         this->hurt(1);
     }
 
@@ -133,7 +133,7 @@ bool goldenApple::mechanics()
 void goldenApple::setCollected(std::shared_ptr<bElem> who)
 {
     collectible::setCollected(who);
-    if (this->isLiveElement() == false && this->attrs->getSubtype() != 0)
+    if (this->isLiveElement() == false && this->getAttrs()->getSubtype() != 0)
     {
         this->registerLiveElement(shared_from_this());
     }

--- a/src/killableElements.cpp
+++ b/src/killableElements.cpp
@@ -34,13 +34,13 @@ bool killableElements::additionalProvisioning(int subtype, int typeId)
 
 bool killableElements::hurt(int points)
 {
-    if (this->attrs->isKillable()==false || this->status->isTeleporting() || this->status->isDying() || this->status->isDestroying())
+    if (this->getAttrs()->isKillable()==false || this->getStats()->isTeleporting() || this->getStats()->isDying() || this->getStats()->isDestroying())
     {
         return false;
     }
 
-    this->attrs->setEnergy(this->attrs->getEnergy()-points);
-    if (this->attrs->getEnergy()<=0)
+    this->getAttrs()->setEnergy(this->getAttrs()->getEnergy()-points);
+    if (this->getAttrs()->getEnergy()<=0)
         this->kill();
     return true;
 }

--- a/src/mechanical.cpp
+++ b/src/mechanical.cpp
@@ -8,7 +8,7 @@ mechanical::mechanical(std::shared_ptr<chamber> board) : mechanical()
 mechanical::~mechanical()
 {
 
-    this->deregisterLiveElement(this->status->getInstanceId());
+    this->deregisterLiveElement(this->getStats()->getInstanceId());
 }
 mechanical::mechanical(std::shared_ptr<chamber> board, bool rEl) : mechanical(board)
 {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -33,7 +33,7 @@ bool monster::additionalProvisioning(int subtype, std::shared_ptr<monster>sbe)
 bool monster::additionalProvisioning(int subtype, int typeId)
 {
     bool res1= bElem::additionalProvisioning(subtype,typeId);
-//  this->attrs->setEnergy(_defaultEnergy);
+//  this->getAttrs()->setEnergy(_defaultEnergy);
 //   this->setInventory(std::make_shared<inventory>()); // setCollect should be true
     if (bElem::randomNumberGenerator() % 2 == 0)
     {
@@ -43,9 +43,9 @@ bool monster::additionalProvisioning(int subtype, int typeId)
     if (bElem::randomNumberGenerator() % 5 == 0)
     {
         this->weapon = elementFactory::generateAnElement<plainGun>(this->getBoard(),0);
-        this->weapon->attrs->setEnergy(((bElem::randomNumberGenerator()*555)%5)*5);
-        this->weapon->attrs->setAmmo(5 * (5 + bElem::randomNumberGenerator() % 55));
-        this->weapon->attrs->setMaxEnergy(5*5*5);
+        this->weapon->getAttrs()->setEnergy(((bElem::randomNumberGenerator()*555)%5)*5);
+        this->weapon->getAttrs()->setAmmo(5 * (5 + bElem::randomNumberGenerator() % 55));
+        this->weapon->getAttrs()->setMaxEnergy(5*5*5);
     }
     return res1;
 }
@@ -83,10 +83,10 @@ bool monster::checkNeigh()
 #ifdef _VerbousMode_
         std::cout<<"  ** CHK isCollectible\n";
 #endif
-        if (e->attrs->isCollectible())
+        if (e->getAttrs()->isCollectible())
         {
             this->collect(e);
-            this->status->setWaiting(_mov_delay);
+            this->getStats()->setWaiting(_mov_delay);
             r = true;
             continue;
         }
@@ -109,60 +109,60 @@ bool monster::checkNeigh()
 #ifdef _VerbousMode_
         std::cout<<"  ** CHK getType Done\n";
 #endif
-        if (this->weapon.get()!=nullptr  || this->attrs->canCollect()) //
+        if (this->weapon.get()!=nullptr  || this->getAttrs()->canCollect()) //
         {
             while (e != nullptr) // this is the "mostervision"
             {
 
-                if (e->getType() == _stash || e->getType() == _rubishType || (e->getType()==_goldenAppleType && e->attrs->getSubtype()!=0) || e->attrs->isWeapon()) // take the direction towards remainings from other objects, broken apples or guns
+                if (e->getType() == _stash || e->getType() == _rubishType || (e->getType()==_goldenAppleType && e->getAttrs()->getSubtype()!=0) || e->getAttrs()->isWeapon()) // take the direction towards remainings from other objects, broken apples or guns
                 {
-                    this->status->setMyDirection(d);
-                    this->status->setFacing(d);
+                    this->getStats()->setMyDirection(d);
+                    this->getStats()->setFacing(d);
                     this->inited = false;
-                    this->status->setWaiting(_mov_delay); // will wait...
+                    this->getStats()->setWaiting(_mov_delay); // will wait...
                     return true;
                 }
 
                 if (
-                    ((e->getType() == _player && e->status->isActive()) || (e->getType() == _patrollingDrone && e->status->hasActivatedMechanics()))
+                    ((e->getType() == _player && e->getStats()->isActive()) || (e->getType() == _patrollingDrone && e->getStats()->hasActivatedMechanics()))
                     &&
-                    ((this->attrs->canCollect() && this->attrs->getInventory()->getActiveWeapon() != nullptr ) || this->weapon != nullptr)
+                    ((this->getAttrs()->canCollect() && this->getAttrs()->getInventory()->getActiveWeapon() != nullptr ) || this->weapon != nullptr)
                 )
                 {
-                    this->status->setFacing(d);
+                    this->getStats()->setFacing(d);
                     if (this->weapon != nullptr)
                     {
                         this->weapon->use(shared_from_this()); // shoot an object with native gun
                     }
                     else
                     {
-                        this->attrs->getInventory()->getActiveWeapon()->use(shared_from_this()); // shoot with the one from the inventory - surprise thing:)
+                        this->getAttrs()->getInventory()->getActiveWeapon()->use(shared_from_this()); // shoot with the one from the inventory - surprise thing:)
                     }
-                    this->status->setWaiting(_mov_delay); // will wait next couple times
+                    this->getStats()->setWaiting(_mov_delay); // will wait next couple times
                     break;
                 }
                 // if it is something interesting, go and fetch it
-                if (e->getType() == _stash || e->getType() == _rubishType || (e->getType()==_goldenAppleType && e->attrs->getSubtype()!=0) || e->attrs->isWeapon()) // take the direction towards remainings from other objects, broken apples or guns
+                if (e->getType() == _stash || e->getType() == _rubishType || (e->getType()==_goldenAppleType && e->getAttrs()->getSubtype()!=0) || e->getAttrs()->isWeapon()) // take the direction towards remainings from other objects, broken apples or guns
                 {
-                    this->status->setMyDirection(d);
-                    this->status->setFacing(d);
+                    this->getStats()->setMyDirection(d);
+                    this->getStats()->setFacing(d);
                     this->inited = false;
-                    this->status->setWaiting(_mov_delay); // will wait...
+                    this->getStats()->setWaiting(_mov_delay); // will wait...
                     return true;
                 }
 
                 // closed door? and we got a key?
-                if ((e->getType() == _door && !e->attrs->isSteppable()) && (this->attrs->getInventory()->countTokens(_door, e->attrs->getSubtype()) > 0))
+                if ((e->getType() == _door && !e->getAttrs()->isSteppable()) && (this->getAttrs()->getInventory()->countTokens(_door, e->getAttrs()->getSubtype()) > 0))
                 {
 
-                    this->status->setMyDirection(d);
+                    this->getStats()->setMyDirection(d);
                     this->inited = false;
-                    this->status->setWaiting(_mov_delay);
+                    this->getStats()->setWaiting(_mov_delay);
                     return true;
 
                 }
                 // we do not see behind non steppable objects
-                if (!e->attrs->isSteppable() || e->getElementInDirection(d) == nullptr)
+                if (!e->getAttrs()->isSteppable() || e->getElementInDirection(d) == nullptr)
                     break;
                 e = e->getElementInDirection(d);
             }
@@ -174,7 +174,7 @@ bool monster::mechanics()
 {
 
     direction newDir = NODIRECTION;
-    direction oldDir = (direction)(((int)this->status->getMyDirection()) % 4);
+    direction oldDir = (direction)(((int)this->getStats()->getMyDirection()) % 4);
     if (!movableElements::mechanics())
         return false;
 //    std::cout<<"   * CHK seppableNeigh\n";
@@ -186,23 +186,23 @@ bool monster::mechanics()
     {
         if (this->isSteppableDirection(oldDir))
         {
-            this->status->setFacing(oldDir);
+            this->getStats()->setFacing(oldDir);
             return this->moveInDirection(oldDir);
         }
-        this->status->setMyDirection((direction)((((int)oldDir) + rotB) % 4));
-        this->status->setFacing(this->status->getMyDirection());
-        oldDir = this->status->getMyDirection();
+        this->getStats()->setMyDirection((direction)((((int)oldDir) + rotB) % 4));
+        this->getStats()->setFacing(this->getStats()->getMyDirection());
+        oldDir = this->getStats()->getMyDirection();
         this->inited = true;
     }
     this->checkNeigh();
-    if (this->status->isWaiting())
+    if (this->getStats()->isWaiting())
         return true;
     for (int c = 0; c < 4; c++)
     {
         newDir = (direction)((((int)oldDir) + rotA) % 4);
         if (this->isSteppableDirection(newDir))
         {
-            this->status->setFacing(newDir);
+            this->getStats()->setFacing(newDir);
             this->moveInDirection(newDir);
             return true;
         }

--- a/src/movableElements.cpp
+++ b/src/movableElements.cpp
@@ -30,20 +30,20 @@ bool movableElements::moveInDirection(direction dir)
 bool movableElements::moveInDirectionSpeed(direction dir, int speed)
 {
     std::shared_ptr<bElem> stepOn=this->getElementInDirection(dir);
-    if (stepOn.get()==nullptr || this->status->isMoving() || this->status->isDying() || this->status->isTeleporting() || this->status->isDestroying() || dir==NODIRECTION)
+    if (stepOn.get()==nullptr || this->getStats()->isMoving() || this->getStats()->isDying() || this->getStats()->isTeleporting() || this->getStats()->isDestroying() || dir==NODIRECTION)
         return false;
-    this->status->setMyDirection(dir);
-    if (stepOn->attrs->isSteppable()==true)
+    this->getStats()->setMyDirection(dir);
+    if (stepOn->getAttrs()->isSteppable()==true)
     {
         this->stepOnElement(stepOn);
-        this->status->setMoved(speed);
+        this->getStats()->setMoved(speed);
         this->playSound("Move","StepOn");
         return true;
     }
-    else if (this->attrs->canPush()==true && stepOn->attrs->canBePushed()==true && stepOn->attrs->isMovable()==true)
+    else if (this->getAttrs()->canPush()==true && stepOn->getAttrs()->canBePushed()==true && stepOn->getAttrs()->isMovable()==true)
     {
         std::shared_ptr<bElem> stepOn2=stepOn->getElementInDirection(dir);
-        if(stepOn2.get()==nullptr || !stepOn2->attrs->isSteppable())
+        if(stepOn2.get()==nullptr || !stepOn2->getAttrs()->isSteppable())
         {
            this->playSound("Move","BlockedMove");
             return false;
@@ -51,12 +51,12 @@ bool movableElements::moveInDirectionSpeed(direction dir, int speed)
         if(stepOn->moveInDirectionSpeed(dir,speed+1)) //move next object in direction
         {
             this->stepOnElement(this->getElementInDirection(dir));  // move the initiating object
-            this->status->setMoved(speed+1);
+            this->getStats()->setMoved(speed+1);
             this->playSound("Move","StepOn");
         }
         return true;
     }
-  /*  if (this->attrs->canCollect() && stepOn->attrs->isCollectible()==true)
+  /*  if (this->getAttrs()->canCollect() && stepOn->getAttrs()->isCollectible()==true)
     {
         if (this->collect(stepOn)==true )
         {
@@ -65,7 +65,7 @@ bool movableElements::moveInDirectionSpeed(direction dir, int speed)
         }
     }
     */
-    if (this->attrs->isInteractive()==true)
+    if (this->getAttrs()->isInteractive()==true)
     {
         if(stepOn->interact(shared_from_this())==true)
         {
@@ -113,12 +113,12 @@ bool movableElements::dragInDirectionSpeed(direction dragIntoDirection, int spee
     std::shared_ptr<bElem> draggedObj=this->getElementInDirection(objFromDir);
     if(draggedObj.get()==nullptr)
         return false;
-    if(!draggedObj->attrs->isMovable())
+    if(!draggedObj->getAttrs()->isMovable())
     {
-        d2=(direction)((((int)this->status->getMyDirection())+2)%4);
+        d2=(direction)((((int)this->getStats()->getMyDirection())+2)%4);
         draggedObj=this->getElementInDirection(d2);
-        d2=this->status->getMyDirection();
-        if(draggedObj.get()==nullptr || !draggedObj->attrs->isMovable())
+        d2=this->getStats()->getMyDirection();
+        if(draggedObj.get()==nullptr || !draggedObj->getAttrs()->isMovable())
             return false;
     }
 
@@ -130,21 +130,21 @@ bool movableElements::dragInDirectionSpeed(direction dragIntoDirection, int spee
 coords movableElements::getOffset() const
 {
     coords res= {0,0};
-    if(this->status->isMoving() && this->status->getMovingTotalTime()>0)
+    if(this->getStats()->isMoving() && this->getStats()->getMovingTotalTime()>0)
     {
-        switch(this->status->getMyDirection())
+        switch(this->getStats()->getMyDirection())
         {
         case(UP):
-            res.y=((this->status->getMoved())*64)/this->status->getMovingTotalTime();
+            res.y=((this->getStats()->getMoved())*64)/this->getStats()->getMovingTotalTime();
             break;
         case (DOWN):
-            res.y=-((this->status->getMoved())*64)/this->status->getMovingTotalTime();
+            res.y=-((this->getStats()->getMoved())*64)/this->getStats()->getMovingTotalTime();
             break;
         case(LEFT):
-            res.x=((this->status->getMoved())*64)/this->status->getMovingTotalTime();
+            res.x=((this->getStats()->getMoved())*64)/this->getStats()->getMovingTotalTime();
             break;
         case(RIGHT):
-            res.x=-((this->status->getMoved())*64)/this->status->getMovingTotalTime();
+            res.x=-((this->getStats()->getMoved())*64)/this->getStats()->getMovingTotalTime();
             break;
         case (NODIRECTION):
             break;

--- a/src/musicElement.cpp
+++ b/src/musicElement.cpp
@@ -16,8 +16,8 @@ musicElement::~musicElement()
 bool musicElement::mechanics()
 {
     if(!bElem::mechanics()) return false;
-    this->status->setWaiting(50);  /* We wait for a while to try to play it again, remember, it will get denied if wrong chamber */
-    soundManager::getInstance()->registerMusic(this->attrs->getSubtype(),this->getBoard()->getInstanceId(), {this->status->getMyPosition().x,0,this->status->getMyPosition().y});
+    this->getStats()->setWaiting(50);  /* We wait for a while to try to play it again, remember, it will get denied if wrong chamber */
+    soundManager::getInstance()->registerMusic(this->getAttrs()->getSubtype(),this->getBoard()->getInstanceId(), {this->getStats()->getMyPosition().x,0,this->getStats()->getMyPosition().y});
     return true;
 }
 bool musicElement::additionalProvisioning(int subtype, std::shared_ptr<musicElement>sbe)

--- a/src/patrollingDrone.cpp
+++ b/src/patrollingDrone.cpp
@@ -9,8 +9,8 @@ patrollingDrone::patrollingDrone(std::shared_ptr<chamber> board) : patrollingDro
 bool patrollingDrone::additionalProvisioning(int subtype,int typeId)
 {
     bool res= bElem::additionalProvisioning(subtype,typeId);
-    this->attrs->setCollect(true);
-    this->attrs->setEnergy((1024*bElem::randomNumberGenerator())%155);
+    this->getAttrs()->setCollect(true);
+    this->getAttrs()->setEnergy((1024*bElem::randomNumberGenerator())%155);
     return res;
 }
 bool patrollingDrone::additionalProvisioning()
@@ -21,7 +21,7 @@ bool patrollingDrone::additionalProvisioning()
 patrollingDrone::patrollingDrone() : killableElements(), movableElements()
 {
 
-    //  this->attrs->setSubtype(0);
+    //  this->getAttrs()->setSubtype(0);
     // this->setInventory(std::make_shared<inventory>());
 
 }
@@ -42,17 +42,17 @@ bool patrollingDrone::additionalProvisioning(int subtype, std::shared_ptr<patrol
 bool patrollingDrone::interact(std::shared_ptr<bElem> who)
 {
     bool res = bElem::interact(who);
-    if (res && !this->brained && this->attrs->getSubtype() == 0 && who->attrs->canCollect())
+    if (res && !this->brained && this->getAttrs()->getSubtype() == 0 && who->getAttrs()->canCollect())
     {
-        std::shared_ptr<bElem> token = who->attrs->getInventory()->requestToken(_puppetMasterType, -1);
+        std::shared_ptr<bElem> token = who->getAttrs()->getInventory()->requestToken(_puppetMasterType, -1);
         if (token)
         {
             this->playSound("Boot", "Success");
             this->brained = true;
             this->brainModule = token;
-            token->status->setCollector(shared_from_this());
+            token->getStats()->setCollector(shared_from_this());
             token->collectOnAction(true,shared_from_this()); // since we collect the object ourselves, we should also trigger the action
-            token->status->setWaiting(55);
+            token->getStats()->setWaiting(55);
             return true;
         }
         this->playSound("Boot", "Failure");

--- a/src/plainGun.cpp
+++ b/src/plainGun.cpp
@@ -22,10 +22,10 @@ std::shared_ptr<bElem> plainGun::createProjectible(std::shared_ptr<bElem> who)
     std::shared_ptr<bElem> pm=elementFactory::generateAnElement<plainMissile>(who->getBoard(),0);
     pm->setStatsOwner(who);
     who->lockThisObject(pm);
-    pm->status->setMyDirection(who->status->getFacing());
-    pm->status->setFacing(who->status->getFacing());
-    pm->stepOnElement(who->getElementInDirection(who->status->getFacing()));
-    pm->attrs->setEnergy(this->attrs->getEnergy());
+    pm->getStats()->setMyDirection(who->getStats()->getFacing());
+    pm->getStats()->setFacing(who->getStats()->getFacing());
+    pm->stepOnElement(who->getElementInDirection(who->getStats()->getFacing()));
+    pm->getAttrs()->setEnergy(this->getAttrs()->getEnergy());
     return pm;
 }
 
@@ -71,41 +71,41 @@ bool plainGun::use(std::shared_ptr<bElem> who)
     }
   ma
 #endif
-   if (this->status->isWaiting())
+   if (this->getStats()->isWaiting())
         return false;
-    this->status->setWaiting(_plainGunCharge);
-    if (this->attrs->getAmmo()<=0 && (this->attrs->getSubtype()%2)==0) //odd subtypes have infinite shots
+    this->getStats()->setWaiting(_plainGunCharge);
+    if (this->getAttrs()->getAmmo()<=0 && (this->getAttrs()->getSubtype()%2)==0) //odd subtypes have infinite shots
         return false;
-    myel=who->getElementInDirection(who->status->getFacing());
+    myel=who->getElementInDirection(who->getStats()->getFacing());
     if(myel!=nullptr)
     {
-        if (this->attrs->getAmmo()>0 || this->attrs->getSubtype()%2==1)
+        if (this->getAttrs()->getAmmo()>0 || this->getAttrs()->getSubtype()%2==1)
         {
 
             coords3d c3d;
-            c3d.x=who->status->getMyPosition().x*32+who->getOffset().x;
-            c3d.z=who->status->getMyPosition().y*32+who->getOffset().y;
+            c3d.x=who->getStats()->getMyPosition().x*32+who->getOffset().x;
+            c3d.z=who->getStats()->getMyPosition().y*32+who->getOffset().y;
             c3d.y=50;
             coords3d vel= {who->getOffset().x,0,who->getOffset().y};
-            soundManager::getInstance()->registerSound(who->getBoard()->getInstanceId(),c3d,vel,this->status->getInstanceId(),this->getType(),this->attrs->getSubtype(),"Shoot","Shoot");
+            soundManager::getInstance()->registerSound(who->getBoard()->getInstanceId(),c3d,vel,this->getStats()->getInstanceId(),this->getType(),this->getAttrs()->getSubtype(),"Shoot","Shoot");
 
-            if (myel->attrs->isSteppable()==true)
+            if (myel->getAttrs()->isSteppable()==true)
             {
                 this->createProjectible(who);
             }
-            else if (myel->attrs->isKillable() )
+            else if (myel->getAttrs()->isKillable() )
             {
                 /*   if(who->getStats()!=nullptr)
                        who->getStats()->countKill(myel);
                        */
-                myel->hurt(this->attrs->getEnergy());
+                myel->hurt(this->getAttrs()->getEnergy());
 
                 // this->disposeElement();
             }
-            if (this->attrs->getSubtype()%2==0)
+            if (this->getAttrs()->getSubtype()%2==0)
             {
-                this->attrs->setAmmo(this->attrs->getAmmo()-1);
-                this->attrs->setEnergy(this->attrs->getEnergy()-(this->attrs->getEnergy()*0.2));
+                this->getAttrs()->setAmmo(this->getAttrs()->getAmmo()-1);
+                this->getAttrs()->setEnergy(this->getAttrs()->getEnergy()-(this->getAttrs()->getEnergy()*0.2));
 
             }
         }
@@ -117,7 +117,7 @@ bool plainGun::use(std::shared_ptr<bElem> who)
 void plainGun::setMaxEnergy(int me)
 {
     this->maxEnergy=me;
-    this->attrs->setEnergy(me);
+    this->getAttrs()->setEnergy(me);
 }
 
 */
@@ -127,10 +127,10 @@ void plainGun::setMaxEnergy(int me)
 bool plainGun::mechanics()
 {
     bool res=mechanical::mechanics();
-    if(this->attrs->getEnergy()<this->maxEnergy)
+    if(this->getAttrs()->getEnergy()<this->maxEnergy)
     {
         if (bElem::getCntr()%5==0)
-            this->attrs->setEnergy(this->attrs->getEnergy()+1);
+            this->getAttrs()->setEnergy(this->getAttrs()->getEnergy()+1);
     }
     return res;
 }

--- a/src/plainMissile.cpp
+++ b/src/plainMissile.cpp
@@ -13,9 +13,9 @@ plainMissile::plainMissile(std::shared_ptr<chamber> mychamber, int energy) : pla
 plainMissile::plainMissile():killableElements(),movableElements(),mechanical()
 {
     this->statsOwner=nullptr;
-    this->status->setWaiting(_plainMissileSpeed);
-    this->status->setMyDirection(UP);
-    this->status->setMoved(0);
+    this->getStats()->setWaiting(_plainMissileSpeed);
+    this->getStats()->setMyDirection(UP);
+    this->getStats()->setMoved(0);
 
 
 }
@@ -54,7 +54,7 @@ bool plainMissile::stepOnAction(bool step, std::shared_ptr<bElem>who)
 {
     if(step && who->getType()!=this->getType())
     {
-        who->hurt(this->attrs->getEnergy());
+        who->hurt(this->getAttrs()->getEnergy());
         this->kill();
     }
     return true;
@@ -74,34 +74,34 @@ bool plainMissile::mechanics()
 
     res=killableElements::mechanics();
     if(!res) return false;
-    if(this->status->isDying() || this->status->isMoving() || this->status->isWaiting())
+    if(this->getStats()->isDying() || this->getStats()->isMoving() || this->getStats()->isWaiting())
         return true;
-    std::shared_ptr<bElem> myel=this->getElementInDirection(this->status->getMyDirection());
-    if(myel==nullptr || myel->status->isDying() || myel->status->isTeleporting() || myel->status->isDestroying())
+    std::shared_ptr<bElem> myel=this->getElementInDirection(this->getStats()->getMyDirection());
+    if(myel==nullptr || myel->getStats()->isDying() || myel->getStats()->isTeleporting() || myel->getStats()->isDestroying())
     {
         this->disposeElement();
         return true;
     }
-    if (myel->attrs->isSteppable()==true)
+    if (myel->getAttrs()->isSteppable()==true)
     {
-        this->moveInDirectionSpeed(this->status->getMyDirection(),_plainMissileSpeed);
+        this->moveInDirectionSpeed(this->getStats()->getMyDirection(),_plainMissileSpeed);
         return true;
     }
-    if (myel->attrs->isKillable()==true)
+    if (myel->getAttrs()->isKillable()==true)
     {
-        myel->hurt(this->attrs->getEnergy());
-        if(!myel->status->isDying() && !myel->status->isDestroying())
+        myel->hurt(this->getAttrs()->getEnergy());
+        if(!myel->getStats()->isDying() && !myel->getStats()->isDestroying())
         {
             this->kill();
         }
         else
         {
-            if (!this->status->isDying())
+            if (!this->getStats()->isDying())
                 this->disposeElement();
         }
         return true;
     }
-    if(myel->status->isDying()|| myel->status->isDestroying()) // if next element in path is already dying, just disappear.
+    if(myel->getStats()->isDying()|| myel->getStats()->isDestroying()) // if next element in path is already dying, just disappear.
         this->disposeElement();
     this->kill();
     return true;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -17,20 +17,19 @@ player::player() : killableElements(), movableElements(), mechanical()
 
 bool player::additionalProvisioning(int subtype,int typeId)
 {
-    //  this->provisioned = true;
-    this->attrs=std::make_unique<bElemAttr>(shared_from_this(),typeId,subtype);
-    this->attrs->setCollect(true);
-    this->attrs->setEnergy(125);
+    bElem::additionalProvisioning(subtype, typeId);
+    this->getAttrs()->setCollect(true);
+    this->getAttrs()->setEnergy(125);
     this->provisioned = true;
     this->registerLiveElement(shared_from_this());
     if ( this->getBoard() && player::allPlayers.size() <= 0)
     {
-        this->status->setActive(true);
-        this->status->setMarked(true);
+        this->getStats()->setActive(true);
+        this->getStats()->setMarked(true);
     }
     else
     {
-        this->status->setActive(false);
+        this->getStats()->setActive(false);
     }
     player::allPlayers.push_back(shared_from_this());
     return true;
@@ -48,15 +47,15 @@ bool player::additionalProvisioning(int subtype, std::shared_ptr<player>sbe)
 
 std::shared_ptr<bElem> player::getActivePlayer()
 {
-    if (player::activePlayer == nullptr || (player::activePlayer && player::activePlayer->status->isDisposed()))
+    if (player::activePlayer == nullptr || (player::activePlayer && player::activePlayer->getStats()->isDisposed()))
     {
         /* find active player, because it is nullptr */
         for (auto p : player::allPlayers)
         {
-            if (p && p->status->isMarked() && !p->status->isDisposed())
+            if (p && p->getStats()->isMarked() && !p->getStats()->isDisposed())
             {
                 player::activePlayer = p;
-                p->status->setActive(true);
+                p->getStats()->setActive(true);
                 if(p->getBoard())
                     soundManager::getInstance()->setListenerChamber(p->getBoard()->getInstanceId());
             }
@@ -75,17 +74,17 @@ unsigned int player::countVisitedPlayers()
 
 oState player::disposeElement()
 {
-    if (this->status->isActive())
+    if (this->getStats()->isActive())
     {
-        this->status->setActive(false);
+        this->getStats()->setActive(false);
         player::activePlayer = nullptr;
         this->getBoard()->player = NOCOORDS;
         if (player::visitedPlayers.size() > 0)
         {
             // Activate next inactive player avatar
             std::shared_ptr<bElem> p = player::visitedPlayers[0];
-            p->status->setActive(true);
-            p->getBoard()->player = p->status->getMyPosition();
+            p->getStats()->setActive(true);
+            p->getBoard()->player = p->getStats()->getMyPosition();
             player::visitedPlayers.erase(player::visitedPlayers.begin());
         }
     }
@@ -112,17 +111,17 @@ oState player::disposeElement()
 
 bool player::interact(std::shared_ptr<bElem> who)
 {
-    if (who == nullptr || this->getBoard() == nullptr || this->status->isActive() || this->status->isMarked() || killableElements::interact(who) == false)
+    if (who == nullptr || this->getBoard() == nullptr || this->getStats()->isActive() || this->getStats()->isMarked() || killableElements::interact(who) == false)
         return false;
 
-    if (who->getType() == this->getType() && !this->status->isActive() && !this->status->isMarked())
+    if (who->getType() == this->getType() && !this->getStats()->isActive() && !this->getStats()->isMarked())
     {
 #ifdef _VerbousMode_
         std::cout << "Adding new avatar\n";
 #endif
         player::visitedPlayers.push_back(shared_from_this());
         this->playSound("Player", "ActivateAvatar");
-        this->status->setMarked(true);
+        this->getStats()->setMarked(true);
     }
     return true;
 }
@@ -133,13 +132,13 @@ bool player::stepOnElement(std::shared_ptr<bElem> step)
 {
     bool r = movableElements::stepOnElement(step);
     bool st=false;
-    if (this->getBoard().get() != nullptr && this->status->isActive())
-        st=this->getBoard()->visitPosition(this->status->getMyPosition()); // we visit the position.
+    if (this->getBoard().get() != nullptr && this->getStats()->isActive())
+        st=this->getBoard()->visitPosition(this->getStats()->getMyPosition()); // we visit the position.
     if(st)
     {
-        this->status->setStats(STEPS,this->status->getStats(STEPS)+(bElem::randomNumberGenerator()%2));
+        this->getStats()->setStats(STEPS,this->getStats()->getStats(STEPS)+(bElem::randomNumberGenerator()%2));
 
-        this->vRadius=2+(std::log(this->status->getStats(STEPS)));
+        this->vRadius=2+(std::log(this->getStats()->getStats(STEPS)));
     }
 
     return r;
@@ -154,21 +153,21 @@ bool player::mechanics()
 {
 
     bool res = bElem::mechanics();
-    if (this->status->isMoving())
+    if (this->getStats()->isMoving())
     {
         if (bElem::getCntr() % 3 == 0)
             this->animPh++;
         return true;
     }
-    if(!res || !this->status->isActive()) return res;
-    this->getBoard()->player.x = this->status->getMyPosition().x;
-    this->getBoard()->player.y = this->status->getMyPosition().y;
+    if(!res || !this->getStats()->isActive()) return res;
+    this->getBoard()->player.x = this->getStats()->getMyPosition().x;
+    this->getBoard()->player.y = this->getStats()->getMyPosition().y;
     coords3d c3d;
-    c3d.x = this->status->getMyPosition().x * 32 + this->getOffset().x;
-    c3d.z = this->status->getMyPosition().y * 32 + this->getOffset().y;
+    c3d.x = this->getStats()->getMyPosition().x * 32 + this->getOffset().x;
+    c3d.z = this->getStats()->getMyPosition().y * 32 + this->getOffset().y;
     c3d.y = 50;
     coords3d vel;
-    switch (this->status->getMyDirection())
+    switch (this->getStats()->getMyDirection())
     {
     case UP:
         vel = {0, 0, -1};
@@ -201,13 +200,13 @@ bool player::mechanics()
     case 0:
         if (this->moveInDirection(this->getBoard()->cntrlItm.dir))
         {
-            this->status->setFacing(this->status->getMyDirection());
+            this->getStats()->setFacing(this->getStats()->getMyDirection());
             //
         }
         break;
 
     case 1:
-        this->status->setFacing(this->getBoard()->cntrlItm.dir);
+        this->getStats()->setFacing(this->getBoard()->cntrlItm.dir);
         if (this->shootGun())
         {
             this->animPh += (bElem::getCntr() % 2);
@@ -217,37 +216,37 @@ bool player::mechanics()
     {
         if (this->getElementInDirection(this->getBoard()->cntrlItm.dir) == nullptr)
             return false;
-        this->status->setFacing(this->getBoard()->cntrlItm.dir);
+        this->getStats()->setFacing(this->getBoard()->cntrlItm.dir);
         std::shared_ptr<bElem> be=this->getElementInDirection(this->getBoard()->cntrlItm.dir);
-        if (be->attrs->isInteractive())
+        if (be->getAttrs()->isInteractive())
             be->interact(shared_from_this());
-        if(be->attrs->isCollectible())
+        if(be->getAttrs()->isCollectible())
             this->collect(be);
         this->animPh++;
         break;
     }
     case 3:
-        this->attrs->getInventory()->nextUsable();
-        this->status->setWaiting(_mov_delay);
+        this->getAttrs()->getInventory()->nextUsable();
+        this->getStats()->setWaiting(_mov_delay);
         break;
     case 4:
         if (this->dragInDirection(this->getBoard()->cntrlItm.dir))
         {
-            this->status->setFacing((direction)(((int)this->status->getMyDirection() + 2) % 4)); /* we face backwards while dragging */
+            this->getStats()->setFacing((direction)(((int)this->getStats()->getMyDirection() + 2) % 4)); /* we face backwards while dragging */
         }
         else if (this->moveInDirection(this->getBoard()->cntrlItm.dir))
         {
-            this->status->setFacing(this->status->getMyDirection());
+            this->getStats()->setFacing(this->getStats()->getMyDirection());
         }
         break;
     case 8:
-        if (this->attrs->getInventory()->getUsable() != nullptr)
-            this->attrs->getInventory()->getUsable()->use(this->getElementInDirection(this->getBoard()->cntrlItm.dir));
+        if (this->getAttrs()->getInventory()->getUsable() != nullptr)
+            this->getAttrs()->getInventory()->getUsable()->use(this->getElementInDirection(this->getBoard()->cntrlItm.dir));
         break;
     case 5:
     {
-        this->attrs->getInventory()->nextGun();
-        this->status->setWaiting(_mov_delay);
+        this->getAttrs()->getInventory()->nextGun();
+        this->getStats()->setWaiting(_mov_delay);
         break;
     }
     case 6:
@@ -259,16 +258,16 @@ bool player::mechanics()
 // shoots any suitable gun
 bool player::shootGun()
 {
-    std::shared_ptr<bElem> gun = this->attrs->getInventory()->getActiveWeapon();
+    std::shared_ptr<bElem> gun = this->getAttrs()->getInventory()->getActiveWeapon();
     if (gun != nullptr)
     {
         if (gun->use(shared_from_this()))
         {
-            this->status->setWaiting(_interactedTime * 2);
+            this->getStats()->setWaiting(_interactedTime * 2);
         };
         return true;
     }
-    this->status->setWaiting(_interactedTime);
+    this->getStats()->setWaiting(_interactedTime);
     return false;
 }
 
@@ -290,7 +289,7 @@ int player::getType() const
 
 int player::getAnimPh() const
 {
-    if (this->status->isTeleporting() || this->status->isDying() || this->status->isDestroying() || !this->status->isActive())
+    if (this->getStats()->isTeleporting() || this->getStats()->isDying() || this->getStats()->isDestroying() || !this->getStats()->isActive())
         return bElem::getAnimPh();
     return this->animPh;
 }

--- a/src/presenter.cpp
+++ b/src/presenter.cpp
@@ -150,37 +150,37 @@ bool presenter::showObjectTile(int x, int y, int offsetX, int offsetY, std::shar
         offsetX=offset.x;
         offsetY=offset.y;
     }
-    if(mode==1 && !elem->status->isMoving())
+    if(mode==1 && !elem->getStats()->isMoving())
         return false;
 
-    if (elem->status->getSteppingOn() && mode!=_mode_onlyTop)
-        res=this->showObjectTile(x,y,offsetX,offsetY,elem->status->getSteppingOn(),ignoreOffset,mode);
-    if((mode==0 && elem->status->isMoving() ))
+    if (elem->getStats()->getSteppingOn() && mode!=_mode_onlyTop)
+        res=this->showObjectTile(x,y,offsetX,offsetY,elem->getStats()->getSteppingOn(),ignoreOffset,mode);
+    if((mode==0 && elem->getStats()->isMoving() ))
         return true;
-    int sType=elem->attrs->getSubtype()%elem->getVideoElementDef()->defArray.size();
-    int sDir=((int)elem->status->getFacing())%elem->getVideoElementDef()->defArray[sType].size();
+    int sType=elem->getAttrs()->getSubtype()%elem->getVideoElementDef()->defArray.size();
+    int sDir=((int)elem->getStats()->getFacing())%elem->getVideoElementDef()->defArray[sType].size();
     int sPh=elem->getAnimPh()%elem->getVideoElementDef()->defArray[sType][sDir].size();
-    if(elem->getType()==_floorType || ( !elem->status->isDying() && !elem->status->isDestroying() && !elem->status->isTeleporting() ))
+    if(elem->getType()==_floorType || ( !elem->getStats()->isDying() && !elem->getStats()->isDestroying() && !elem->getStats()->isTeleporting() ))
     {
         coords=elem->getVideoElementDef()->defArray[sType][sDir][sPh];
         draw_sprite();
         if (!elem->getType()==_floorType)
             return res;
     }
-    if (elem->status->isDying())
+    if (elem->getStats()->isDying())
     {
         coords=elem->getVideoElementDef()->dying[elem->getAnimPh()%(elem->getVideoElementDef()->dying.size())];
         draw_sprite();
         return res;
     }
-    if (elem->status->isDestroying())
+    if (elem->getStats()->isDestroying())
     {
         coords=elem->getVideoElementDef()->dying[elem->getAnimPh()%(elem->getVideoElementDef()->destroying.size())];
         draw_sprite();
         return res;
     }
 
-    if(elem->status->isFading())
+    if(elem->getStats()->isFading())
     {
         coords=elem->getVideoElementDef()->dying[elem->getAnimPh()%(elem->getVideoElementDef()->fadingOut.size())];
         draw_sprite();
@@ -189,7 +189,7 @@ bool presenter::showObjectTile(int x, int y, int offsetX, int offsetY, std::shar
     }
 
 
-    if (elem->status->isTeleporting())
+    if (elem->getStats()->isTeleporting())
     {
         coords=elem->getVideoElementDef()->teleporting[elem->getAnimPh()%(elem->getVideoElementDef()->teleporting.size())];
         draw_sprite();
@@ -221,30 +221,30 @@ void presenter::prepareStatsThing()
     this->showText(1,1,0,5,"Garden: "+aPlayer->getBoard()->getName());
     this->showObjectTile(1,0,0,0,aPlayer,true,_mode_onlyTop);
     this->showText(2,0,0,0,std::to_string(player::countVisitedPlayers()));
-    this->showText(2,0,0,32,std::to_string(aPlayer->attrs->getEnergy()));
-    this->showObjectTile(4,0,0,0,aPlayer->attrs->getInventory()->getActiveWeapon(),true,_mode_onlyTop);
+    this->showText(2,0,0,32,std::to_string(aPlayer->getAttrs()->getEnergy()));
+    this->showObjectTile(4,0,0,0,aPlayer->getAttrs()->getInventory()->getActiveWeapon(),true,_mode_onlyTop);
 
 
 
-    if( aPlayer->attrs->getInventory()->getActiveWeapon()!=nullptr)
+    if( aPlayer->getAttrs()->getInventory()->getActiveWeapon()!=nullptr)
     {
-        this->showText(5,0,0,32,std::to_string(aPlayer->attrs->getInventory()->getActiveWeapon()->attrs->getEnergy()));
-        this->showText(5,0,0,0,std::to_string(aPlayer->attrs->getInventory()->getActiveWeapon()->attrs->getAmmo()));
+        this->showText(5,0,0,32,std::to_string(aPlayer->getAttrs()->getInventory()->getActiveWeapon()->getAttrs()->getEnergy()));
+        this->showText(5,0,0,0,std::to_string(aPlayer->getAttrs()->getInventory()->getActiveWeapon()->getAttrs()->getAmmo()));
     }
     for (int cnt=0; cnt<5; cnt++)
     {
         int tokens;
-        std::shared_ptr<bElem> key=aPlayer->attrs->getInventory()->getKey(_key,cnt,false);
+        std::shared_ptr<bElem> key=aPlayer->getAttrs()->getInventory()->getKey(_key,cnt,false);
         if(key!=nullptr)
         {
-            tokens=aPlayer->attrs->getInventory()->countTokens(key->getType(),key->attrs->getSubtype());
+            tokens=aPlayer->getAttrs()->getInventory()->countTokens(key->getType(),key->getAttrs()->getSubtype());
             this->showObjectTile(7+(cnt*2),0,0,0,key,true,_mode_onlyTop);
             this->showText(8+(cnt*2),0,0,16,std::to_string(tokens));
         }
     }
     this->showObjectTile(18,0,0,0,goldenApple::getApple(1),true,_mode_onlyTop);
     this->showText(19,0,0,0,std::to_string(goldenApple::getAppleNumber()));
-    this->showText(19,0,0,32,std::to_string(aPlayer->attrs->getInventory()->countTokens(_goldenAppleType,0)));
+    this->showText(19,0,0,32,std::to_string(aPlayer->getAttrs()->getInventory()->countTokens(_goldenAppleType,0)));
     this->showText(21,0,6,0,"Stats");
     this->showText(21,0,5,32,"P:");
     this->showText(21,1,5,0,"Dex:");
@@ -265,7 +265,7 @@ void presenter::showGameField()
 
 
     std::shared_ptr<bElem> player=player::getActivePlayer();
-    coords b=player->status->getMyPosition()-(coords)
+    coords b=player->getStats()->getMyPosition()-(coords)
     {
         (this->scrTilesX)/2,(this->scrTilesY)/2
     };
@@ -311,7 +311,7 @@ void presenter::showGameField()
     for(unsigned int cnt=0; cnt<mSprites.size(); cnt++)
     {
         movingSprite ms=mSprites.at(cnt);
-        if(ms.elem->status->getInstanceId()==player->status->getInstanceId())
+        if(ms.elem->getStats()->getInstanceId()==player->getStats()->getInstanceId())
         {
             px=ms.x;
             py=ms.y;
@@ -320,8 +320,8 @@ void presenter::showGameField()
         else
             this->showObjectTile(ms.x,ms.y,0,0,ms.elem,false,1);
     }
-    if(player->status->isMoving() && player->getBoard()->width>player->status->getMyPosition().x && player->status->getMyPosition().x>=0 && player->getBoard()->height>player->status->getMyPosition().y && player->status->getMyPosition().y>=0)
-        this->showObjectTile(px,py,0,0,player->getBoard()->getElement(player->status->getMyPosition()),false,1);
+    if(player->getStats()->isMoving() && player->getBoard()->width>player->getStats()->getMyPosition().x && player->getStats()->getMyPosition().x>=0 && player->getBoard()->height>player->getStats()->getMyPosition().y && player->getStats()->getMyPosition().y>=0)
+        this->showObjectTile(px,py,0,0,player->getBoard()->getElement(player->getStats()->getMyPosition()),false,1);
 
     if(player->getBoard().get()!=nullptr)
     {
@@ -332,7 +332,7 @@ void presenter::showGameField()
             for(y=-1; y<this->scrTilesY+2; y++)
             {
                 int obscured;
-                coords point=player->status->getMyPosition();
+                coords point=player->getStats()->getMyPosition();
                 int nx=x+this->previousPosition.x;
                 int ny=y+this->previousPosition.y;
                 float distance=point.distance((coords)
@@ -465,7 +465,7 @@ int presenter::presentEverything()
             if(currentPlayer.get()!=nullptr)
             {
                 this->_cp_attachedBoard=player::getActivePlayer()->getBoard();
-                if(currentPlayer->attrs->getInventory()->countTokens(_goldenAppleType,0)==goldenApple::getAppleNumber())
+                if(currentPlayer->getAttrs()->getInventory()->countTokens(_goldenAppleType,0)==goldenApple::getAppleNumber())
                     this->fin=true;
             }
             bElem::runLiveElements();

--- a/src/puppetMasterFR.cpp
+++ b/src/puppetMasterFR.cpp
@@ -28,16 +28,16 @@ bool puppetMasterFR::collectOnAction(bool c, std::shared_ptr<bElem>who)
     {
         if(who->getType() == _patrollingDrone)
         {
-            if (this->attrs->getSubtype() == 0) // if subtype not set, set one randomly
+            if (this->getAttrs()->getSubtype() == 0) // if subtype not set, set one randomly
             {
-                this->attrs->setSubtype(2);
-                this->attrs->setSubtype(this->randomNumberGenerator()%2);
+                this->getAttrs()->setSubtype(2);
+                this->getAttrs()->setSubtype(this->randomNumberGenerator()%2);
             }
             this->registerLiveElement(shared_from_this());
         }
     }
-    else if(this->status->hasActivatedMechanics())
-        this->deregisterLiveElement(this->status->getInstanceId());
+    else if(this->getStats()->hasActivatedMechanics())
+        this->deregisterLiveElement(this->getStats()->getInstanceId());
 
     return true;
 }
@@ -47,10 +47,10 @@ bool puppetMasterFR::mechanics()
 {
     bool res = mechanical::mechanics();
 
-    std::shared_ptr<bElem> clc = this->status->getCollector().lock();
-    if (res && clc.get() != nullptr && clc->getType() == _patrollingDrone && !clc->status->isMoving() && !clc->status->isWaiting())
+    std::shared_ptr<bElem> clc = this->getStats()->getCollector().lock();
+    if (res && clc.get() != nullptr && clc->getType() == _patrollingDrone && !clc->getStats()->isMoving() && !clc->getStats()->isWaiting())
     {
-        switch (this->attrs->getSubtype()) // here we will route all the mechanics, when we are in the monster
+        switch (this->getAttrs()->getSubtype()) // here we will route all the mechanics, when we are in the monster
         {
         case 0:
             return this->mechanicsPatrollingDrone();
@@ -67,20 +67,20 @@ bool puppetMasterFR::mechanics()
 
 bool puppetMasterFR::collectorMechanics()
 {
-    std::shared_ptr<bElem> _collector=this->status->getCollector().lock();
+    std::shared_ptr<bElem> _collector=this->getStats()->getCollector().lock();
     for(int c=0; c<4; c++)
     {
-        direction d=_collector->status->getMyDirection();
+        direction d=_collector->getStats()->getMyDirection();
         d=(direction)(((int)d+c)%4);
         std::shared_ptr<bElem> check=this->findObjectInDirection(d);
 
-        if(check && check->attrs->isCollectible())
+        if(check && check->getAttrs()->isCollectible())
         {
-            if(_collector->status->getMyDirection()!=d)
+            if(_collector->getStats()->getMyDirection()!=d)
             {
-                _collector->status->setMyDirection(d);
-                _collector->status->setFacing(d);
-                this->status->setWaiting(5);
+                _collector->getStats()->setMyDirection(d);
+                _collector->getStats()->setFacing(d);
+                this->getStats()->setWaiting(5);
                 return true;
 
             }
@@ -93,9 +93,9 @@ bool puppetMasterFR::collectorMechanics()
 
 std::shared_ptr<bElem> puppetMasterFR::findObjectInDirection(direction dir)
 {
-    std::shared_ptr<bElem> b = this->status->getCollector().lock();
+    std::shared_ptr<bElem> b = this->getStats()->getCollector().lock();
     b=b->getElementInDirection(dir);
-    while(b!=nullptr && b->attrs->isSteppable())
+    while(b!=nullptr && b->getAttrs()->isSteppable())
     {
         b=b->getElementInDirection(dir);
     }
@@ -104,26 +104,26 @@ std::shared_ptr<bElem> puppetMasterFR::findObjectInDirection(direction dir)
 
 bool puppetMasterFR::mechanicsPatrollingDrone()
 {
-    std::shared_ptr<bElem> collector = this->status->getCollector().lock();
-    direction cdir = collector->status->getMyDirection();
+    std::shared_ptr<bElem> collector = this->getStats()->getCollector().lock();
+    direction cdir = collector->getStats()->getMyDirection();
     direction pdir1 = (direction)((((int)cdir) + 1) % 4);
     direction pdir2 = (direction)((((int)cdir) + 3) % 4);
     bool b1 = false, b2 = false;
     if (collector->getElementInDirection(pdir1))
-        b1 = collector->getElementInDirection(pdir1)->attrs->isSteppable();
+        b1 = collector->getElementInDirection(pdir1)->getAttrs()->isSteppable();
     if (collector->getElementInDirection(pdir2))
-        b2 = collector->getElementInDirection(pdir2)->attrs->isSteppable();
+        b2 = collector->getElementInDirection(pdir2)->getAttrs()->isSteppable();
     int roulette=this->randomNumberGenerator() %55;
     if (b1 && roulette == 5) // same probablility for each
     {
-        collector->status->setMyDirection(pdir1);
-        collector->status->setWaiting(3);
+        collector->getStats()->setMyDirection(pdir1);
+        collector->getStats()->setWaiting(3);
         return true;
     }
     else if (b2 && roulette==25)
     {
-        collector->status->setMyDirection(pdir1);
-        collector->status->setWaiting(3);
+        collector->getStats()->setMyDirection(pdir1);
+        collector->getStats()->setWaiting(3);
         return true;
     }
     bool r = collector->moveInDirection(cdir);
@@ -131,8 +131,8 @@ bool puppetMasterFR::mechanicsPatrollingDrone()
     {
         int f = (this->randomNumberGenerator() % 2 == 0) ? 1 : 3;
         cdir = (direction)((((int)cdir) + f) % 4);
-        collector->status->setMyDirection(cdir);
-        collector->status->setWaiting(3);
+        collector->getStats()->setMyDirection(cdir);
+        collector->getStats()->setWaiting(3);
         return true;
     }
     return r;

--- a/src/randomLevelGenerator.cpp
+++ b/src/randomLevelGenerator.cpp
@@ -149,7 +149,7 @@ chamberArea* randomLevelGenerator::lvlGenerate(int x1, int y1, int x2, int y2,in
         //we draw vertical line
         for (int a=y1; a<=y2; a++)
         {
-            if (this->mychamber->getElement(c+2,a) && a!=d && this->mychamber->getElement(c,a)->attrs->isSteppable()==true && this->mychamber->getElement(c+2,a)->attrs->isSteppable()==true)
+            if (this->mychamber->getElement(c+2,a) && a!=d && this->mychamber->getElement(c,a)->getAttrs()->isSteppable()==true && this->mychamber->getElement(c+2,a)->getAttrs()->isSteppable()==true)
             {
                 if (a<d+2)
                 {
@@ -160,7 +160,7 @@ chamberArea* randomLevelGenerator::lvlGenerate(int x1, int y1, int x2, int y2,in
                     doorPlaces2.push_back(a);
                 }
             }
-            if (this->mychamber->getElement(c+1,a)->attrs->isSteppable())
+            if (this->mychamber->getElement(c+1,a)->getAttrs()->isSteppable())
             {
                 std::shared_ptr<bElem> newElement=elementFactory::generateAnElement<wall>(this->mychamber,0);
                 newElement->stepOnElement(this->mychamber->getElement(c+1,a));
@@ -205,7 +205,7 @@ chamberArea* randomLevelGenerator::lvlGenerate(int x1, int y1, int x2, int y2,in
                 continue;
             }
 
-            if (a!=c && this->mychamber->getElement(a,d)->attrs->isSteppable()==true && this->mychamber->getElement(a,d+2)->attrs->isSteppable()==true)
+            if (a!=c && this->mychamber->getElement(a,d)->getAttrs()->isSteppable()==true && this->mychamber->getElement(a,d+2)->getAttrs()->isSteppable()==true)
             {
                 if (a<c+2)
                 {
@@ -216,7 +216,7 @@ chamberArea* randomLevelGenerator::lvlGenerate(int x1, int y1, int x2, int y2,in
                     doorPlaces2.push_back(a);
                 }
             }
-            if (mychamber->getElement(a,d+1)->attrs->isSteppable())
+            if (mychamber->getElement(a,d+1)->getAttrs()->isSteppable())
             {
                 std::shared_ptr<bElem> newElement=elementFactory::generateAnElement<wall>(this->mychamber,0);
                 newElement->stepOnElement(this->mychamber->getElement(a,d+1));
@@ -506,12 +506,12 @@ bool randomLevelGenerator::placeDoors(elementToPlace element,chamberArea* locati
     //Ok, now we need to place the door.
     for(int c1=location->upLeft.x-1; c1<=location->downRight.x+1; c1++)
     {
-        if (this->mychamber->getElement(c1,location->upLeft.y-1)->attrs->isSteppable())
+        if (this->mychamber->getElement(c1,location->upLeft.y-1)->getAttrs()->isSteppable())
         {
             std::shared_ptr<bElem> neEl=this->createElement(element);
             neEl->stepOnElement(this->mychamber->getElement(c1,location->upLeft.y-1));
         }
-        if (this->mychamber->getElement(c1,location->downRight.y+1)->attrs->isSteppable())
+        if (this->mychamber->getElement(c1,location->downRight.y+1)->getAttrs()->isSteppable())
         {
             std::shared_ptr<bElem> neEl=this->createElement(element);
             neEl->stepOnElement(this->mychamber->getElement(c1,location->downRight.y+1));
@@ -519,12 +519,12 @@ bool randomLevelGenerator::placeDoors(elementToPlace element,chamberArea* locati
     }
     for (int c2=location->upLeft.y; c2<=location->downRight.y; c2++)
     {
-        if (this->mychamber->getElement(location->upLeft.x-1,c2)->attrs->isSteppable())
+        if (this->mychamber->getElement(location->upLeft.x-1,c2)->getAttrs()->isSteppable())
         {
             std::shared_ptr<bElem> neEl=this->createElement(element);
             neEl->stepOnElement(this->mychamber->getElement(location->upLeft.x-1,c2));
         }
-        if (this->mychamber->getElement(location->downRight.x+1,c2)->attrs->isSteppable())
+        if (this->mychamber->getElement(location->downRight.x+1,c2)->getAttrs()->isSteppable())
         {
             std::shared_ptr<bElem> neEl=this->createElement(element);
             neEl->stepOnElement(this->mychamber->getElement(location->downRight.x+1,c2));

--- a/src/rubbish.cpp
+++ b/src/rubbish.cpp
@@ -27,9 +27,9 @@ videoElement::videoElementDef* rubbish::getVideoElementDef()
 bool rubbish::mechanics()
 {
     std::shared_ptr<bElem> t=shared_from_this();
-    this->deregisterLiveElement(this->status->getInstanceId());
-    if( this->status->hasParent() && this->status->getStandingOn().lock()->attrs->canCollect())
-        this->status->getStandingOn().lock()->collect(t);
+    this->deregisterLiveElement(this->getStats()->getInstanceId());
+    if( this->getStats()->hasParent() && this->getStats()->getStandingOn().lock()->getAttrs()->canCollect())
+        this->getStats()->getStandingOn().lock()->collect(t);
     return false;
 }
 bool rubbish::additionalProvisioning()
@@ -40,7 +40,7 @@ bool rubbish::additionalProvisioning()
 bool rubbish::additionalProvisioning(int subtype,int typeId)
 {
     bool res=bElem::additionalProvisioning(subtype,typeId);
-    this->attrs->setEnergy(1);
+    this->getAttrs()->setEnergy(1);
 
     return res;
 }

--- a/src/simpleBomb.cpp
+++ b/src/simpleBomb.cpp
@@ -41,14 +41,14 @@ bool simpleBomb::destroy()
     }
     this->registerLiveElement(shared_from_this());
     this->triggered = true;
-    this->status->setWaiting(5); /* magic number */
+    this->getStats()->setWaiting(5); /* magic number */
     return true;
 }
 
 bool simpleBomb::mechanics()
 {
     bElem::mechanics();
-    if (this->status->getWaiting() > 1)
+    if (this->getStats()->getWaiting() > 1)
         return false;
     this->explode(1.5);
     return true;

--- a/src/stackedElement.cpp
+++ b/src/stackedElement.cpp
@@ -48,15 +48,15 @@ bool stackedElement::stepOnElement(std::shared_ptr<bElem> step)
         this->removeElement();
         for(unsigned int c=this->topDownConstruct.size(); c>0; c--)
         {
-            if(this->topDownConstruct[c-1]->status->getInstanceId()!=this->status->getInstanceId())
+            if(this->topDownConstruct[c-1]->getStats()->getInstanceId()!=this->getStats()->getInstanceId())
             {
-                res=this->topDownConstruct[c-1]->stepOnElement(step->getBoard()->getElement(step->status->getMyPosition()));
+                res=this->topDownConstruct[c-1]->stepOnElement(step->getBoard()->getElement(step->getStats()->getMyPosition()));
             }
             if(!res) // this should actually happen only with the first element, the rest must be composed so the whole object can be created
                 break;
         }
     }
-    std::shared_ptr<bElem> be=step->getBoard()->getElement(step->status->getMyPosition());
+    std::shared_ptr<bElem> be=step->getBoard()->getElement(step->getStats()->getMyPosition());
     res=movableElements::stepOnElement(be);
     return res;
 }
@@ -72,7 +72,7 @@ std::shared_ptr<bElem> stackedElement::removeElement()
     {
         for(unsigned int c=0; c<this->topDownConstruct.size(); c++)
         {
-            if(this->status->getInstanceId()==this->topDownConstruct[c]->status->getInstanceId())
+            if(this->getStats()->getInstanceId()==this->topDownConstruct[c]->getStats()->getInstanceId())
             {
                 cnt=movableElements::removeElement();
                 continue;
@@ -89,5 +89,5 @@ std::shared_ptr<bElem> stackedElement::removeElement()
 void stackedElement::linkAnElement(std::shared_ptr<stackedElement> newBottom)
 {
     this->topDownConstruct.push_back(newBottom);
-    if(this->status->getInstanceId()!=newBottom->status->getInstanceId()) newBottom->setController(shared_from_this());
+    if(this->getStats()->getInstanceId()!=newBottom->getStats()->getInstanceId()) newBottom->setController(shared_from_this());
 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -66,7 +66,7 @@ bool teleport::createConnectionsWithinSUbtype()
     for (unsigned int c = 0; c < teleport::allTeleporters.size(); c++)
     {
         std::shared_ptr<teleport> t=teleport::allTeleporters[c].lock();
-        if (!teleport::allTeleporters[c].expired() && t->attrs->getSubtype() == this->attrs->getSubtype())
+        if (!teleport::allTeleporters[c].expired() && t->getAttrs()->getSubtype() == this->getAttrs()->getSubtype())
         {
             t->connectionsMade = true;
             candidates.push_back(t);
@@ -93,13 +93,13 @@ int teleport::getType() const
 // Teleport to this becon
 bool teleport::teleportIt(std::shared_ptr<bElem> who)
 {
-    int dir = (int)who->status->getMyDirection();
+    int dir = (int)who->getStats()->getMyDirection();
     if (this->checked)
         return false;
     this->checked = true;
-    who->status->setTelInProgress(_teleportationTime);
-    if (who->status->getSteppingOn() != nullptr)
-        who->status->getSteppingOn()->status->setTelInProgress(_teleportationTime);
+    who->getStats()->setTelInProgress(_teleportationTime);
+    if (who->getStats()->getSteppingOn() != nullptr)
+        who->getStats()->getSteppingOn()->getStats()->setTelInProgress(_teleportationTime);
     for (int c = 0; c < 4; c++)
     {
         direction d = (direction)((dir + c) % 4);
@@ -115,13 +115,13 @@ bool teleport::teleportIt(std::shared_ptr<bElem> who)
 /*
 bool teleport::isSteppable()
 {
-    if (this->attrs->getSubtype() > 0)
+    if (this->getAttrs()->getSubtype() > 0)
     {
-        if (this->status->isTeleporting())
+        if (this->getStats()->isTeleporting())
             return false;
         if (this->theOtherEnd != nullptr)
         {
-            if (this->theOtherEnd->status->getStandingOn() == nullptr)
+            if (this->theOtherEnd->getStats()->getStandingOn() == nullptr)
             {
                 return true;
             }
@@ -142,7 +142,7 @@ bool teleport::isSteppable()
 void teleport::stomp(std::shared_ptr<bElem> who)
 {
     bElem::stomp(who);
-    this->status->setWaiting(_teleportStandTime);
+    this->getStats()->setWaiting(_teleportStandTime);
     this->registerLiveElement(shared_from_this());
 }
 
@@ -150,18 +150,18 @@ void teleport::unstomp()
 {
     bElem::unstomp();
     if (this->isLiveElement())
-        this->deregisterLiveElement(this->status->getInstanceId());
+        this->deregisterLiveElement(this->getStats()->getInstanceId());
 }
 */
 bool teleport::mechanics()
 {
 
-    if (!this->status->isWaiting())
+    if (!this->getStats()->isWaiting())
     {
-        if (this->status->hasParent())
+        if (this->getStats()->hasParent())
         {
-            this->interact(this->status->getStandingOn().lock());
-            this->deregisterLiveElement(this->status->getInstanceId());
+            this->interact(this->getStats()->getStandingOn().lock());
+            this->deregisterLiveElement(this->getStats()->getInstanceId());
         }
     };
     this->playSound("Teleport", "HummingSound");
@@ -173,7 +173,7 @@ bool teleport::removeFromAllTeleporters()
     for (unsigned int c = 0; c < teleport::allTeleporters.size(); c++)
     {
         std::shared_ptr<teleport> t=teleport::allTeleporters[c].lock();
-        if (!teleport::allTeleporters[c].expired() && t->attrs->getSubtype() == this->attrs->getSubtype())
+        if (!teleport::allTeleporters[c].expired() && t->getAttrs()->getSubtype() == this->getAttrs()->getSubtype())
         {
             t->connectionsMade = false;
         }
@@ -181,7 +181,7 @@ bool teleport::removeFromAllTeleporters()
     for (unsigned int c = 0; c < teleport::allTeleporters.size();)
     {
     std::shared_ptr<teleport> t=teleport::allTeleporters[c].lock();
-        if (teleport::allTeleporters[c].expired() || t->status->getInstanceId() == this->status->getInstanceId())
+        if (teleport::allTeleporters[c].expired() || t->getStats()->getInstanceId() == this->getStats()->getInstanceId())
         {
             teleport::allTeleporters.erase(teleport::allTeleporters.begin() + c);
         }

--- a/src/wall.cpp
+++ b/src/wall.cpp
@@ -10,7 +10,7 @@ wall::wall(std::shared_ptr<chamber> board) : wall()
 wall::wall(std::shared_ptr<chamber> board, int subtype) : wall(board)
 {
 
-  //  this->attrs->setSubtype(subtype);
+  //  this->getAttrs()->setSubtype(subtype);
 }
 
 wall::wall() : bElem()
@@ -35,14 +35,14 @@ bool wall::stepOnElement(std::shared_ptr<bElem> elem)
 {
     bool res = bElem::stepOnElement(elem);
     if (this->getBoard().get() != nullptr)
-        this->getBoard()->setVisible(this->status->getMyPosition(), 254);
+        this->getBoard()->setVisible(this->getStats()->getMyPosition(), 254);
     return res;
 }
 
 std::shared_ptr<bElem> wall::removeElement()
 {
     if (this->getBoard().get() != nullptr)
-        this->getBoard()->setVisible(this->status->getMyPosition(), 255);
+        this->getBoard()->setVisible(this->getStats()->getMyPosition(), 255);
     std::shared_ptr<bElem> res = bElem::removeElement();
     return res;
 }


### PR DESCRIPTION
no more direct exposure of stats and attrs objects, these are now available via getters. 
it has implications: 

- only bElem can create the objects, so invoke bElem::additionalProvisioning(subtype, typeId), when creating your own method for that
- it is now possible to pass a foreign stats member, and manipulate it - good for shooting
what is missing:

- thread safety